### PR TITLE
fix(numeric-query): Type cast numeric query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,17 @@ Options:
 - `route <string>`: A route for which the documentation will be served at
 - `document <object>`: Base document on top of which the paths will be added
 - `options <object>`: Options object
+  - `options.coerce`: Enable data type [`coercion`](https://www.npmjs.com/package/ajv#coercing-data-types)
   - `options.htmlui`: Turn on serving `redoc` or `swagger-ui` html ui
+
+##### Coerce
+
+By default `coerceTypes` is set to `true` for AJV, but a copy of the `req` data
+is passed to prevent modifying the `req` in an unexpected way.  This is because
+the `coerceTypes` option in (AJV modifies the input)[https://github.com/epoberezkin/ajv/issues/549].
+If this is the behavior you want, you can pass `true` for this and a copy will not be made.
+This will result in params in the path or query with type `number` will be converted
+to numbers [based on the rules from AJV](https://github.com/epoberezkin/ajv/blob/master/COERCION.md).
 
 ### `OpenApiMiddleware.path([definition])`
 

--- a/index.js
+++ b/index.js
@@ -9,12 +9,14 @@ const minimumViableDocument = require('./lib/minimum-doc')
 const generateDocument = require('./lib/generate-doc')
 const defaultRoutePrefix = '/openapi'
 
-module.exports = function ExpressOpenApi (_routePrefix, _doc, opts = {}) {
+module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
   let routePrefix = _routePrefix || defaultRoutePrefix
   let doc = _doc || minimumViableDocument
-  if (typeof routePrefix !== 'string') {
-    doc = _routePrefix || doc
+  let opts = _opts || {}
+  if (typeof _routePrefix !== 'string') {
     routePrefix = defaultRoutePrefix
+    doc = _routePrefix || minimumViableDocument
+    opts = _doc || _opts || {}
   }
 
   // We need to route a bit, seems a safe addition
@@ -54,7 +56,7 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, opts = {}) {
     let validate
     function validSchemaMiddleware (req, res, next) {
       if (!validate) {
-        validate = makeValidator(middleware, getSchema(validSchemaMiddleware))
+        validate = makeValidator(middleware, getSchema(validSchemaMiddleware), opts)
       }
       return validate(req, res, next)
     }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -5,7 +5,7 @@ const merge = require('merge-deep')
 
 const BASE_REQ_SCHEMA = {
   type: 'object',
-  required: ['headers', 'params', 'query', 'body'],
+  required: ['headers', 'params', 'query'],
   properties: {
     headers: {
       type: 'object',
@@ -30,7 +30,7 @@ const BASE_REQ_SCHEMA = {
   }
 }
 
-module.exports = function makeValidatorMiddleware (middleware, schema) {
+module.exports = function makeValidatorMiddleware (middleware, schema, opts) {
   let ajv
   let validate
 
@@ -86,7 +86,9 @@ module.exports = function makeValidatorMiddleware (middleware, schema) {
 
     // Create ajv instance on first request
     if (!ajv) {
-      ajv = new Ajv()
+      ajv = new Ajv({
+        coerceTypes: opts.coerce === 'false' ? opts.coerce : true
+      })
     }
 
     if (!validate) {
@@ -94,7 +96,11 @@ module.exports = function makeValidatorMiddleware (middleware, schema) {
     }
 
     // Validate request
-    const validationStatus = validate(req)
+    let r = req
+    if (opts.coerce !== true) {
+      r = makeReqCopy(req)
+    }
+    const validationStatus = validate(r)
     if (validationStatus === true) {
       return next()
     }
@@ -105,4 +111,16 @@ module.exports = function makeValidatorMiddleware (middleware, schema) {
     err.validationSchema = validate.schema
     next(httpErrors(400, err))
   }
+}
+
+// This is because ajv modifies the original data,
+// preventing this requires that we dont pass the
+// actual req.  An issue has been opened (@TODO open the issue)
+function makeReqCopy (req) {
+  return JSON.parse(JSON.stringify({
+    headers: req.headers,
+    params: req.params,
+    query: req.query,
+    body: req.body
+  }))
 }


### PR DESCRIPTION
Example url: 
http://example.com/path?age=42

Schema:
```
{
    name: 'age',
    in: 'query',
    required: true,
    schema: {
        type: 'integer'
    },
    description: 'Identifier of the project'
}
```

Expectation:  
AJV validation passes

Actual result: 
```
"validationErrors": [
    {
      "keyword": "type",
      "dataPath": ".query.pdmProjectId",
      "schemaPath": "#/properties/query/properties/age/type",
      "params": {
        "type": "integer"
      },
      "message": "should be integer"
    }
```