### PR TITLE
feature addition: Support nested routers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "javascript.validate.enable": false,
+  "standard.enable": true,
+  "standard.autoFixOnSave": true
+}

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
       if (!middleware.document.components || !middleware.document.components[type] || !middleware.document.components[type][name]) {
         throw new Error(`Unknown ${type} ref: ${name}`)
       }
-      return { '$ref': `#/components/${type}/${name}` }
+      return { $ref: `#/components/${type}/${name}` }
     }
 
     // @TODO create id

--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 const pathToRegexp = require('path-to-regexp')
 const minimumViableDocument = require('./minimum-doc')
 const { get: getSchema, set: setSchema } = require('./layer-schema')
@@ -40,7 +40,7 @@ module.exports = function generateDocument (baseDocument, router) {
             }
 
             // Reformat the path
-            keys[k.name] = '{' + k.name + '}';
+            keys[k.name] = '{' + k.name + '}'
 
             return Object.assign(
               {
@@ -72,7 +72,7 @@ module.exports = function generateDocument (baseDocument, router) {
     })
 
   return doc
-};
+}
 
 function iterateStack (path, routeLayer, layer, cb) {
   cb(path, routeLayer, layer)
@@ -80,7 +80,7 @@ function iterateStack (path, routeLayer, layer, cb) {
   // handle nested routes
   if (layer.name === 'router') {
     layer.handle.stack.forEach(l => {
-      path = path || '';
+      path = path || ''
       iterateStack(path + split(layer.regexp).join('/'), layer, l, cb)
     })
   }
@@ -107,6 +107,6 @@ function split (thing) {
       .match(/^\/\^((?:\\[.*+?^${}()|[\]\\/]|[^.*+?^${}()|[\]\\/])*)\$\//)
     return match
       ? match[1].replace(/\\(.)/g, '$1').split('/')
-      : '<complex:' + thing.toString() + '>';
+      : '<complex:' + thing.toString() + '>'
   }
 }

--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -98,7 +98,7 @@ function split (thing) {
   if (typeof thing === 'string') {
     return thing.split('/')
   } else if (thing.fast_slash) {
-    return ''
+    return []
   } else {
     var match = thing
       .toString()

--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -5,69 +5,108 @@ const { get: getSchema, set: setSchema } = require('./layer-schema')
 
 module.exports = function generateDocument (baseDocument, router) {
   // Merge document with select minimum defaults
-  const doc = Object.assign({
-    openapi: minimumViableDocument.openapi
-  }, baseDocument, {
-    info: Object.assign({}, minimumViableDocument.info, baseDocument.info),
-    paths: Object.assign({}, minimumViableDocument.paths, baseDocument.paths)
-  })
+  const doc = Object.assign(
+    {
+      openapi: minimumViableDocument.openapi
+    },
+    baseDocument,
+    {
+      info: Object.assign({}, minimumViableDocument.info, baseDocument.info),
+      paths: Object.assign({}, minimumViableDocument.paths, baseDocument.paths)
+    }
+  )
 
   // Iterate the middleware stack and add any paths and schemas, etc
-  router && router.stack.forEach((_layer) => {
-    iterateStack('', null, _layer, (path, routeLayer, layer) => {
-      const schema = getSchema(layer.handle)
-      if (!schema || !layer.method) {
-        return
-      }
-
-      const operation = Object.assign({}, schema)
-
-      // Add route params to schema
-      if (routeLayer && routeLayer.keys && routeLayer.keys.length) {
-        const keys = {}
-
-        const params = routeLayer.keys.map((k) => {
-          let param
-          if (schema.parameters) {
-            param = schema.parameters.find((p) => p.name === k.name && p.in === 'path')
-          }
-
-          // Reformat the path
-          keys[k.name] = '{' + k.name + '}'
-
-          return Object.assign({
-            name: k.name,
-            in: 'path',
-            required: !k.optional,
-            schema: { type: 'string' }
-          }, param || {})
-        })
-
-        if (schema.parameters) {
-          schema.parameters.forEach((p) => {
-            if (!params.find((pp) => p.name === pp.name)) {
-              params.push(p)
-            }
-          })
+  router &&
+    router.stack.forEach(_layer => {
+      iterateStack('', null, _layer, (path, routeLayer, layer) => {
+        const schema = getSchema(layer.handle)
+        if (!schema || !layer.method) {
+          return
         }
 
-        operation.parameters = params
-        path = pathToRegexp.compile(path)(keys, { encode: (value) => value })
-      }
+        const operation = Object.assign({}, schema)
 
-      doc.paths[path] = doc.paths[path] || {}
-      doc.paths[path][layer.method] = operation
-      setSchema(layer.handle, operation)
+        // Add route params to schema
+        if (routeLayer && routeLayer.keys && routeLayer.keys.length) {
+          const keys = {}
+
+          const params = routeLayer.keys.map(k => {
+            let param
+            if (schema.parameters) {
+              param = schema.parameters.find(
+                p => p.name === k.name && p.in === 'path'
+              )
+            }
+
+            // Reformat the path
+            keys[k.name] = '{' + k.name + '}'
+
+            return Object.assign(
+              {
+                name: k.name,
+                in: 'path',
+                required: !k.optional,
+                schema: { type: 'string' }
+              },
+              param || {}
+            )
+          })
+
+          if (schema.parameters) {
+            schema.parameters.forEach(p => {
+              if (!params.find(pp => p.name === pp.name)) {
+                params.push(p)
+              }
+            })
+          }
+
+          operation.parameters = params
+          path = pathToRegexp.compile(path)(keys, { encode: value => value })
+        }
+
+        doc.paths[path] = doc.paths[path] || {}
+        doc.paths[path][layer.method] = operation
+        setSchema(layer.handle, operation)
+      })
     })
-  })
 
   return doc
 }
 
 function iterateStack (path, routeLayer, layer, cb) {
   cb(path, routeLayer, layer)
+
+  // handle nested routes
+  if (layer.name === 'router') {
+    layer.handle.stack.forEach(l => {
+      path = path || ''
+      iterateStack(path + split(layer.regexp).join('/'), layer, l, cb)
+    })
+  }
+
   if (!layer.route) {
     return
   }
-  layer.route.stack.forEach((l) => iterateStack(path + layer.route.path, layer, l, cb))
+  layer.route.stack.forEach(l =>
+    iterateStack(path + layer.route.path, layer, l, cb)
+  )
+}
+
+// https://github.com/expressjs/express/issues/3308#issuecomment-300957572
+function split (thing) {
+  if (typeof thing === 'string') {
+    return thing.split('/')
+  } else if (thing.fast_slash) {
+    return ''
+  } else {
+    var match = thing
+      .toString()
+      .replace('\\/?', '')
+      .replace('(?=\\/|$)', '$')
+      .match(/^\/\^((?:\\[.*+?^${}()|[\]\\/]|[^.*+?^${}()|[\]\\/])*)\$\//)
+    return match
+      ? match[1].replace(/\\(.)/g, '$1').split('/')
+      : '<complex:' + thing.toString() + '>'
+  }
 }

--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 const pathToRegexp = require('path-to-regexp')
 const minimumViableDocument = require('./minimum-doc')
 const { get: getSchema, set: setSchema } = require('./layer-schema')
@@ -40,7 +40,7 @@ module.exports = function generateDocument (baseDocument, router) {
             }
 
             // Reformat the path
-            keys[k.name] = '{' + k.name + '}'
+            keys[k.name] = '{' + k.name + '}';
 
             return Object.assign(
               {
@@ -72,7 +72,7 @@ module.exports = function generateDocument (baseDocument, router) {
     })
 
   return doc
-}
+};
 
 function iterateStack (path, routeLayer, layer, cb) {
   cb(path, routeLayer, layer)
@@ -80,7 +80,7 @@ function iterateStack (path, routeLayer, layer, cb) {
   // handle nested routes
   if (layer.name === 'router') {
     layer.handle.stack.forEach(l => {
-      path = path || ''
+      path = path || '';
       iterateStack(path + split(layer.regexp).join('/'), layer, l, cb)
     })
   }
@@ -107,6 +107,6 @@ function split (thing) {
       .match(/^\/\^((?:\\[.*+?^${}()|[\]\\/]|[^.*+?^${}()|[\]\\/])*)\$\//)
     return match
       ? match[1].replace(/\\(.)/g, '$1').split('/')
-      : '<complex:' + thing.toString() + '>'
+      : '<complex:' + thing.toString() + '>';
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 const { suite, test } = require('mocha')
 const assert = require('assert')
 const util = require('util')

--- a/test/index.js
+++ b/test/index.js
@@ -109,7 +109,7 @@ suite(name, function () {
       })
   })
 
-  test('support express array formats', (done) => {
+  test('support express array formats', done => {
     const app = express()
     const oapi = openapi()
 
@@ -118,7 +118,7 @@ suite(name, function () {
         204: {
           description: 'Successful response',
           content: {
-            'application/json': { }
+            'application/json': {}
           }
         }
       }
@@ -128,12 +128,20 @@ suite(name, function () {
     app.get('/undocumented', (req, res) => {
       res.status(204).send()
     })
-    app.get('/array', [emptySchema, (req, res) => {
-      res.status(204).send()
-    }])
-    app.get('/array-of-arrays', [[emptySchema, (req, res) => {
-      res.status(204).send()
-    }]])
+    app.get('/array', [
+      emptySchema,
+      (req, res) => {
+        res.status(204).send()
+      }
+    ])
+    app.get('/array-of-arrays', [
+      [
+        emptySchema,
+        (req, res) => {
+          res.status(204).send()
+        }
+      ]
+    ])
 
     supertest(app)
       .get(`${openapi.defaultRoutePrefix}.json`)
@@ -148,12 +156,18 @@ suite(name, function () {
           assert(api.paths['/array'])
           assert(api.paths['/array'].get)
           assert(api.paths['/array'].get.responses[204])
-          assert.strictEqual(api.paths['/array'].get.responses[204].description, 'Successful response')
+          assert.strictEqual(
+            api.paths['/array'].get.responses[204].description,
+            'Successful response'
+          )
 
           assert(api.paths['/array-of-arrays'])
           assert(api.paths['/array-of-arrays'].get)
           assert(api.paths['/array-of-arrays'].get.responses[204])
-          assert.strictEqual(api.paths['/array-of-arrays'].get.responses[204].description, 'Successful response')
+          assert.strictEqual(
+            api.paths['/array-of-arrays'].get.responses[204].description,
+            'Successful response'
+          )
 
           assert(!api.paths['/undocumented'])
 
@@ -162,7 +176,7 @@ suite(name, function () {
       })
   })
 
-  test('support express route syntax', (done) => {
+  test('support express route syntax', done => {
     const app = express()
     const oapi = openapi()
 
@@ -171,14 +185,15 @@ suite(name, function () {
         204: {
           description: 'Successful response',
           content: {
-            'application/json': { }
+            'application/json': {}
           }
         }
       }
     })
 
     app.use(oapi)
-    app.route('/route')
+    app
+      .route('/route')
       .get(emptySchema, (req, res) => {
         res.status(204).send()
       })
@@ -186,7 +201,8 @@ suite(name, function () {
         res.status(204).send()
       })
 
-    app.route('/route-all')
+    app
+      .route('/route-all')
       .all(emptySchema)
       .all((req, res) => {
         res.status(204).send()
@@ -205,18 +221,24 @@ suite(name, function () {
           assert(api.paths['/route'])
           assert(api.paths['/route'].get)
           assert(api.paths['/route'].get.responses[204])
-          assert.strictEqual(api.paths['/route'].get.responses[204].description, 'Successful response')
+          assert.strictEqual(
+            api.paths['/route'].get.responses[204].description,
+            'Successful response'
+          )
 
           assert(api.paths['/route'].put)
           assert(api.paths['/route'].put.responses[204])
-          assert.strictEqual(api.paths['/route'].put.responses[204].description, 'Successful response')
+          assert.strictEqual(
+            api.paths['/route'].put.responses[204].description,
+            'Successful response'
+          )
 
           done()
         })
       })
   })
 
-  test('support named path params', (done) => {
+  test('support named path params', done => {
     const app = express()
     const oapi = openapi()
 
@@ -225,7 +247,7 @@ suite(name, function () {
         204: {
           description: 'Successful response',
           content: {
-            'application/json': { }
+            'application/json': {}
           }
         }
       }
@@ -256,7 +278,7 @@ suite(name, function () {
       })
   })
 
-  test('support parameter components', (done) => {
+  test('support parameter components', done => {
     const app = express()
     const oapi = openapi()
 
@@ -268,30 +290,87 @@ suite(name, function () {
     })
 
     app.use(oapi)
-    app.get('/:id', oapi.path({
-      description: 'Get thing by id',
-      parameters: [ oapi.parameters('id') ],
-      responses: {
-        204: {
-          description: 'Successful response',
-          content: {
-            'application/json': { }
+    app.get(
+      '/:id',
+      oapi.path({
+        description: 'Get thing by id',
+        parameters: [oapi.parameters('id')],
+        responses: {
+          204: {
+            description: 'Successful response',
+            content: {
+              'application/json': {}
+            }
           }
         }
+      }),
+      (req, res) => {
+        res.status(204).send()
       }
-    }), (req, res) => {
-      res.status(204).send()
-    })
+    )
 
     supertest(app)
       .get(`${openapi.defaultRoutePrefix}/validate`)
       .expect(200, (err, res) => {
         assert(!err, err)
         assert.strictEqual(res.body.valid, true)
-        assert.strictEqual(res.body.document.components.parameters.id.name, 'id')
-        assert.strictEqual(res.body.document.components.parameters.id.description, 'The entity id')
+        assert.strictEqual(
+          res.body.document.components.parameters.id.name,
+          'id'
+        )
+        assert.strictEqual(
+          res.body.document.components.parameters.id.description,
+          'The entity id'
+        )
         assert.strictEqual(res.status, 200)
         done()
+      })
+  })
+
+  test('support express sub-routes with Router', done => {
+    const app = express()
+    const oapi = openapi()
+    const router = express.Router()
+
+    const emptySchema = oapi.path({
+      responses: {
+        204: {
+          description: 'Successful response',
+          content: {
+            'application/json': {}
+          }
+        }
+      }
+    })
+
+    app.use(oapi)
+
+    router.get('/endpoint', emptySchema, (req, res) => {
+      res.status(204).send()
+    })
+
+    app.use('/sub-route', router)
+
+    supertest(app)
+      .get(`${openapi.defaultRoutePrefix}.json`)
+      .expect(200, (err, res) => {
+        assert(!err, err)
+        SwaggerParser.validate(res.body, (err, api) => {
+          if (err) {
+            logDocument(api)
+            done(err)
+          }
+
+          assert(api.paths['/sub-route/endpoint'])
+          assert(api.paths['/sub-route/endpoint'].get)
+          assert(api.paths['/sub-route/endpoint'].get.responses[204])
+          assert.strictEqual(
+            api.paths['/sub-route/endpoint'].get.responses[204].description,
+            'Successful response'
+          )
+
+          done()
+        })
       })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 const { suite, test } = require('mocha')
 const assert = require('assert')
 const util = require('util')


### PR DESCRIPTION
Currently, nested Express routers are not supported:

```
const app = express()
const oapi = openapi()
const router = express.Router()
app.use(oapi)

router.get('/endpoint', emptySchema, (req, res) => {
   res.status(204).send()
})

app.use('/sub-route', router)
```

This PR adds the ability for this to support such a feature.