### PR TITLE
Set the UI HTML title to "Swagger UI" or "ReDoc"

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -4,7 +4,7 @@ const serve = require('serve-static')
 
 module.exports.serveRedoc = function serveRedoc (documentUrl) {
   return [serve(path.resolve(require.resolve('redoc'), '..')), function renderRedocHtml (req, res) {
-    res.type('html').send(renderHtmlPage(`
+    res.type('html').send(renderHtmlPage('ReDoc', `
       <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
     `, `
       <redoc spec-url="${documentUrl}"></redoc>
@@ -15,7 +15,7 @@ module.exports.serveRedoc = function serveRedoc (documentUrl) {
 
 module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl) {
   return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }), function renderSwaggerHtml (req, res) {
-    res.type('html').send(renderHtmlPage(`
+    res.type('html').send(renderHtmlPage('Swagger UI', `
       <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
     `, `
       <div id="swagger-ui"></div>
@@ -33,11 +33,11 @@ module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl) {
   }]
 }
 
-function renderHtmlPage (head, body) {
+function renderHtmlPage (title, head, body) {
   return `<!DOCTYPE html>
 <html>
   <head>
-    <title>ReDoc</title>
+    <title>${title}</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>

--- a/test/index.js
+++ b/test/index.js
@@ -69,6 +69,30 @@ suite(name, function () {
       })
   })
 
+  test('create a basic valid Swagger UI document and check the HTML title', function (done) {
+    const app = express()
+    app.use(openapi().swaggerui)
+    supertest(app)
+      .get(`${openapi.defaultRoutePrefix}.json`)
+      .end((err, res) => {
+        assert(!err, err)
+        assert(res.text.includes('<title>Swagger UI</title>'))
+        done()
+      })
+  })
+
+  test('create a basic valid ReDoc document and check the HTML title', function (done) {
+    const app = express()
+    app.use(openapi().redoc)
+    supertest(app)
+      .get(`${openapi.defaultRoutePrefix}.json`)
+      .end((err, res) => {
+        assert(!err, err)
+        assert(res.text.includes('<title>ReDoc</title>'))
+        done()
+      })
+  })
+
   test('load routes from the express app', function (done) {
     const app = express()
     const oapi = openapi()


### PR DESCRIPTION
It was previously always setting the HTML title to "ReDoc", regardless of whether it was rendering ReDoc or Swagger UI.

I added tests, which might be overkill...

I didn't run this change past you first so it's totally on me if you want anything altered or would prefer to just cancel this PR. Thanks!