### PR TITLE
Allowing apps to configure the path schema and its type

### DIFF
--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -39,7 +39,7 @@ module.exports = function generateDocument (baseDocument, router) {
             name: k.name,
             in: 'path',
             required: !k.optional,
-            schema: { type: 'string' }
+            schema: k.schema || { type: 'string' }
           }, param || {})
         })
 

--- a/test/index.js
+++ b/test/index.js
@@ -314,6 +314,47 @@ suite(name, function () {
         assert.strictEqual(res.body.valid, true)
         assert.strictEqual(res.body.document.components.parameters.id.name, 'id')
         assert.strictEqual(res.body.document.components.parameters.id.description, 'The entity id')
+        assert.strictEqual(res.body.document.components.parameters.id.schema.type, 'string')
+        assert.strictEqual(res.status, 200)
+        done()
+      })
+  })
+
+  test('support a non-string path parameter', (done) => {
+    const app = express()
+    const oapi = openapi()
+
+    oapi.parameters('id', {
+      in: 'path',
+      required: true,
+      description: 'The numeric User ID',
+      schema: { type: 'integer' }
+    })
+
+    app.use(oapi)
+    app.get('/:id', oapi.path({
+      description: 'Get a user by ID',
+      parameters: [ oapi.parameters('id') ],
+      responses: {
+        204: {
+          description: 'Successful response',
+          content: {
+            'application/json': { }
+          }
+        }
+      }
+    }), (req, res) => {
+      res.status(204).send()
+    })
+
+    supertest(app)
+      .get(`${openapi.defaultRoutePrefix}/validate`)
+      .expect(200, (err, res) => {
+        assert(!err, err)
+        assert.strictEqual(res.body.valid, true)
+        assert.strictEqual(res.body.document.components.parameters.id.name, 'id')
+        assert.strictEqual(res.body.document.components.parameters.id.description, 'The numeric User ID')
+        assert.strictEqual(res.body.document.components.parameters.id.schema.type, 'integer')
         assert.strictEqual(res.status, 200)
         done()
       })


### PR DESCRIPTION
This reopens the PR #27 again (initially opened by @r3na). We moved the source of the old PR, therefore it was auto-closed... Sorry for this circumstance.

---

The type should be provided by the app as well and not hard coded as "string".
https://github.com/wesleytodd/express-openapi/blob/a38331330f005a91527bea28cb78521c5293cf8b/lib/generate-doc.js#L42

Parameters can be "integer" for example.
https://swagger.io/docs/specification/describing-parameters/