### PR TITLE
fix(devdeps): update dev deps to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
       if (!middleware.document.components || !middleware.document.components[type] || !middleware.document.components[type][name]) {
         throw new Error(`Unknown ${type} ref: ${name}`)
       }
-      return { '$ref': `#/components/${type}/${name}` }
+      return { $ref: `#/components/${type}/${name}` }
     }
 
     // @TODO create id

--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -86,7 +86,7 @@ function split (thing) {
   } else if (thing.fast_slash) {
     return []
   } else {
-    var match = thing
+    const match = thing
       .toString()
       .replace('\\/?', '')
       .replace('(?=\\/|$)', '$')

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -50,6 +50,7 @@ module.exports = function makeValidatorMiddleware (middleware, schema, opts) {
           p.required && !reqSchema.properties.query.required.includes(p.name) && reqSchema.properties.query.required.push(p.name)
           break
         case 'header':
+          // eslint-disable-next-line no-case-declarations
           const name = p.name.toLowerCase()
           reqSchema.properties.headers.properties[name] = p.schema
           p.required && !reqSchema.properties.headers.required.includes(p.name) && reqSchema.properties.headers.required.push(name)

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "postpublish": "git push origin && git push origin --tags"
   },
   "devDependencies": {
-    "express": "^4.16.4",
-    "mocha": "^5.2.0",
-    "standard": "^12.0.1",
-    "supertest": "^3.3.0"
+    "express": "^4.18.2",
+    "mocha": "^10.2.0",
+    "standard": "^17.1.0",
+    "supertest": "^6.3.3"
   },
   "dependencies": {
     "ajv": "^6.10.2",

--- a/test/_validate.js
+++ b/test/_validate.js
@@ -1,9 +1,9 @@
 'use strict'
-var { suite, test } = require('mocha')
-var assert = require('assert')
-var supertest = require('supertest')
-var express = require('express')
-var openapi = require('..')
+const { suite, test } = require('mocha')
+const assert = require('assert')
+const supertest = require('supertest')
+const express = require('express')
+const openapi = require('..')
 
 module.exports = function () {
   suite('validate', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -294,7 +294,7 @@ suite(name, function () {
     app.use(oapi)
     app.get('/:id', oapi.path({
       description: 'Get thing by id',
-      parameters: [ oapi.parameters('id') ],
+      parameters: [oapi.parameters('id')],
       responses: {
         204: {
           description: 'Successful response',


### PR DESCRIPTION
Honestly I think this is considered a breaking change because of the lint changing `var` to `const`. Technically this drops some versions before node 6. The saving grace here is that we are pre 1.x so any release can be breaking. Also, 6 is old, like old old. I am fine dropping it here so I am going to go ahead with this as a `minor`.