### PR TITLE
Updating prod deps

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -88,7 +88,8 @@ module.exports = function makeValidatorMiddleware (middleware, schema, opts) {
     // Create ajv instance on first request
     if (!ajv) {
       ajv = new Ajv({
-        coerceTypes: opts.coerce === 'false' ? opts.coerce : true
+        coerceTypes: opts.coerce === 'false' ? opts.coerce : true,
+        strict: opts.strict === true ? opts.strict : false
       })
     }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.12.0",
     "http-errors": "^2.0.0",
     "merge-deep": "^3.0.2",
-    "path-to-regexp": "^2.4.0",
+    "path-to-regexp": "^6.2.1",
     "redoc": "^2.0.0-alpha.41",
     "router": "^1.3.3",
     "serve-static": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "router": "^1.3.3",
     "serve-static": "^1.13.2",
     "swagger-parser": "^10.0.3",
-    "swagger-ui-dist": "^3.20.2"
+    "swagger-ui-dist": "^5.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "redoc": "^2.0.0-alpha.41",
     "router": "^1.3.3",
     "serve-static": "^1.13.2",
-    "swagger-parser": "^6.0.5",
+    "swagger-parser": "^10.0.3",
     "swagger-ui-dist": "^3.20.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "supertest": "^6.3.3"
   },
   "dependencies": {
-    "ajv": "^6.10.2",
+    "ajv": "^8.12.0",
     "http-errors": "^1.7.3",
     "merge-deep": "^3.0.2",
     "path-to-regexp": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "ajv": "^8.12.0",
-    "http-errors": "^1.7.3",
+    "http-errors": "^2.0.0",
     "merge-deep": "^3.0.2",
     "path-to-regexp": "^2.4.0",
     "redoc": "^2.0.0-alpha.41",

--- a/test/_validate.js
+++ b/test/_validate.js
@@ -82,7 +82,7 @@ module.exports = function () {
         })
 
       assert.strictEqual(res2.statusCode, 400)
-      assert.strictEqual(res2.body.validationErrors[0].dataPath, '.body.hello')
+      assert.strictEqual(res2.body.validationErrors[0].instancePath, '/body/hello')
 
       const res3 = await supertest(app)
         .post('/bar')
@@ -92,7 +92,7 @@ module.exports = function () {
         })
 
       assert.strictEqual(res3.statusCode, 400)
-      assert.strictEqual(res3.body.validationErrors[0].dataPath, '.headers')
+      assert.strictEqual(res3.body.validationErrors[0].instancePath, '/headers')
       assert.strictEqual(res3.body.validationErrors[0].params.missingProperty, 'x-custom-header')
     })
 


### PR DESCRIPTION
Updating `ajv` is a breaking change to the validation in two ways:

1. We are defaulting strict to false. The error here was confusing, and honestly we probably need a test for that mode
2. The http response data is changed for errors from `dataPath` to `instancePath`

Updating `path-to-regexp` is interesting because it is out of sync with `express@4` which is at `0.1.7`. It was always though, and since we haven't gotten any complaints about that so far I guess we should be alright?


As with the changes to the dev deps I think we are alright breaking since we are pre-1.x