### PR TITLE
Use ajv-formats to support OpenAPI string formats: "date", "password", etc...

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,5 +1,6 @@
 'use strict'
 const Ajv = require('ajv')
+const addFormats = require('ajv-formats')
 const httpErrors = require('http-errors')
 const merge = require('merge-deep')
 
@@ -91,6 +92,7 @@ module.exports = function makeValidatorMiddleware (middleware, schema, opts) {
         coerceTypes: opts.coerce === 'false' ? opts.coerce : true,
         strict: opts.strict === true ? opts.strict : false
       })
+      addFormats(ajv)
     }
 
     if (!validate) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
     "http-errors": "^2.0.0",
     "merge-deep": "^3.0.2",
     "path-to-regexp": "^6.2.1",

--- a/test/_validate.js
+++ b/test/_validate.js
@@ -30,7 +30,8 @@ module.exports = function () {
               schema: {
                 type: 'object',
                 properties: {
-                  hello: { type: 'string', enum: ['world'] }
+                  hello: { type: 'string', enum: ['world'] },
+                  birthday: { type: 'string', format: 'date' }
                 }
               }
             }

--- a/test/_validate.js
+++ b/test/_validate.js
@@ -95,6 +95,18 @@ module.exports = function () {
       assert.strictEqual(res3.statusCode, 400)
       assert.strictEqual(res3.body.validationErrors[0].instancePath, '/headers')
       assert.strictEqual(res3.body.validationErrors[0].params.missingProperty, 'x-custom-header')
+
+      const res4 = await supertest(app)
+        .post('/bar?num=123')
+        .set('X-Custom-Header', 'value')
+        .send({
+          hello: 'world',
+          birthday: 'bad date',
+          foo: 'bar'
+        })
+
+      assert.strictEqual(res4.statusCode, 400)
+      assert.strictEqual(res4.body.validationErrors[0].instancePath, '/body/birthday')
     })
 
     test('coerce types on req', async function () {


### PR DESCRIPTION
"date" and other [OpenAPI formats](https://swagger.io/docs/specification/data-models/data-types/#format) were being ignored. Entries like this one were shown in the logs:

> unknown format "date" ignored in schema at path "#/properties/body/properties/Birthdate/anyOf/1"

Used [ajv-formats](https://ajv.js.org/packages/ajv-formats.html) to support this, as starting from Ajv v7.x, formats are in a separate package/repository.

Cheers!
