### PR TITLE
Feat: add support for base path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Options:
 - `options <object>`: Options object
   - `options.coerce`: Enable data type [`coercion`](https://www.npmjs.com/package/ajv#coercing-data-types)
   - `options.htmlui`: Turn on serving `redoc` or `swagger-ui` html ui
+  - `options.basePath`: When set, will strip the value of `basePath` from the start of every path.
 
 ##### Coerce
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
   // Where the magic happens
   const middleware = function OpenApiMiddleware (req, res, next) {
     if (isFirstRequest) {
-      middleware.document = generateDocument(middleware.document, req.app._router || req.app.router)
+      middleware.document = generateDocument(middleware.document, req.app._router || req.app.router, opts.basePath)
       isFirstRequest = false
     }
 

--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -3,7 +3,7 @@ const pathToRegexp = require('path-to-regexp')
 const minimumViableDocument = require('./minimum-doc')
 const { get: getSchema, set: setSchema } = require('./layer-schema')
 
-module.exports = function generateDocument (baseDocument, router) {
+module.exports = function generateDocument (baseDocument, router, basePath) {
   // Merge document with select minimum defaults
   const doc = Object.assign({
     openapi: minimumViableDocument.openapi
@@ -15,6 +15,9 @@ module.exports = function generateDocument (baseDocument, router) {
   // Iterate the middleware stack and add any paths and schemas, etc
   router && router.stack.forEach((_layer) => {
     iterateStack('', null, _layer, (path, routeLayer, layer) => {
+      if (basePath) {
+        path = path.replace(basePath, '')
+      }
       const schema = getSchema(layer.handle)
       if (!schema || !layer.method) {
         return

--- a/test/index.js
+++ b/test/index.js
@@ -491,6 +491,55 @@ suite(name, function () {
       })
   })
 
+  test('support express nested sub-routes with base path', (done) => {
+    const app = express()
+    const router = express.Router()
+    const subrouter = express.Router()
+    const oapi = openapi(undefined, { basePath: '/sub-route' })
+
+    const emptySchema = oapi.path({
+      responses: {
+        204: {
+          description: 'Successful response',
+          content: {
+            'application/json': {}
+          }
+        }
+      }
+    })
+
+    subrouter.get('/endpoint', emptySchema, (req, res) => {
+      res.status(204).send()
+    })
+
+    app.use(oapi)
+    app.use('/sub-route', router)
+    router.use('/sub-sub-route', subrouter)
+
+    supertest(app)
+      .get(`${openapi.defaultRoutePrefix}.json`)
+      .expect(200, (err, res) => {
+        assert(!err, err)
+        SwaggerParser.validate(res.body, (err, api) => {
+          if (err) {
+            logDocument(api)
+
+            done(err)
+          }
+
+          assert(api.paths['/sub-sub-route/endpoint'])
+          assert(api.paths['/sub-sub-route/endpoint'].get)
+          assert(api.paths['/sub-sub-route/endpoint'].get.responses[204])
+          assert.strictEqual(
+            api.paths['/sub-sub-route/endpoint'].get.responses[204].description,
+            'Successful response'
+          )
+
+          done()
+        })
+      })
+  })
+
   // Other tests
   require('./_validate')()
   require('./_routes')()


### PR DESCRIPTION
This PR is in reference to #33.

This is the simplest form of the changes required to make this work for Unleash's use case for this library. It accepts an optional basePath argument and uses that to strip the leading paths for any paths it writes.

However, it only handles the simplest case, because that's all we need. I think I'd like to avoid handling any more cases specifically just yet, because I don't think we know what to expect in those cases (so we can't prepare for them fully). However, this is of course open for discussion.

I've written a short line to the readme explaining what this is, but I'd be happy to expand upon it if you want a full paragraph or the like.

Please have a look, see what you think, and we'll take it from there 😄 