### PR TITLE
refactor: serve swagger-ui from a script (not inline JS)

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -14,23 +14,32 @@ module.exports.serveRedoc = function serveRedoc (documentUrl) {
 }
 
 module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl) {
-  return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }), function renderSwaggerHtml (req, res) {
-    res.type('html').send(renderHtmlPage('Swagger UI', `
+  return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }),
+    function returnUiInit (req, res, next) {
+      if (req.path.endsWith('/swagger-ui-init.js')) {
+        res.type('.js')
+        res.send(`window.onload = function () {
+  window.ui = SwaggerUIBundle({
+    url: "${documentUrl}",
+    dom_id: '#swagger-ui'
+  })
+}
+        `)
+      } else {
+        next()
+      }
+    },
+    function renderSwaggerHtml (req, res) {
+      res.type('html').send(renderHtmlPage('Swagger UI', `
       <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
     `, `
       <div id="swagger-ui"></div>
       <script src="./swagger-ui-bundle.js"></script>
       <script src="./swagger-ui-standalone-preset.js"></script>
-      <script>
-        window.onload = function () {
-          window.ui = SwaggerUIBundle({
-            url: "${documentUrl}",
-            dom_id: '#swagger-ui'
-          })
-        }
-      </script>
+      <script src="./swagger-ui-init.js"></script>
     `))
-  }]
+    }
+  ]
 }
 
 function renderHtmlPage (title, head, body) {

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,18 @@ suite(name, function () {
       })
   })
 
+  test('serves onload function in swagger-ui-init.js file', function (done) {
+    const app = express()
+    app.use(openapi().swaggerui)
+    supertest(app)
+      .get(`${openapi.defaultRoutePrefix}/swagger-ui-init.js`)
+      .end((err, res) => {
+        assert(!err, err)
+        assert(res.text.includes('window.onload = function () {'))
+        done()
+      })
+  })
+
   test('create a basic valid ReDoc document and check the HTML title', function (done) {
     const app = express()
     app.use(openapi().redoc)


### PR DESCRIPTION
This PR refactors the swagger-ui to be served from a script file, rather than from inline JS.

This gets around the [CSP](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#1-restricting-inline-scripts) issues Unleash were having with inline JS (as described in [this PR to Unleash's old fork](https://github.com/Unleash/express-openapi/pull/5)).

> Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' cdn.getunleash.io". Either the 'unsafe-inline' keyword, a hash ('sha256-f6ODck6GG+BFHrHDNsNQtQEHSyG3iP8zBIQEAqqyK/E='), or a nonce ('nonce-...') is required to enable inline execution.

This PR takes the simple approach of serving the script from the same function as the swagger UI HTML instead of creating a separate file for it. I'm happy to discuss it if you don't think it's the right approach.

The redoc UI appears to already use a separate script file (and Unleash does not use that), so I've not touched it.