### PR TITLE
Enable configuration of SwaggerUI and Redoc via their configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Options:
   - `options.coerce`: Enable data type [`coercion`](https://www.npmjs.com/package/ajv#coercing-data-types)
   - `options.htmlui`: Turn on serving `redoc` or `swagger-ui` html ui
   - `options.basePath`: When set, will strip the value of `basePath` from the start of every path.
+The options object can also accept configuration parameters for Swagger and Redoc. The full list of Swagger and Redoc configuration options can be found here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/ and here: https://redocly.com/docs/redoc/config/ respectively.
 
 ##### Coerce
 

--- a/index.js
+++ b/index.js
@@ -127,8 +127,8 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
   middleware.callbacks = middleware.component.bind(null, 'callbacks')
 
   // Expose ui middleware
-  middleware.redoc = ui.serveRedoc(`${routePrefix}.json`)
-  middleware.swaggerui = ui.serveSwaggerUI(`${routePrefix}.json`)
+  middleware.redoc = ui.serveRedoc(`${routePrefix}.json`, opts)
+  middleware.swaggerui = ui.serveSwaggerUI(`${routePrefix}.json`, opts)
 
   // OpenAPI document as json
   router.get(`${routePrefix}.json`, (req, res) => {

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -2,27 +2,46 @@
 const path = require('path')
 const serve = require('serve-static')
 
-module.exports.serveRedoc = function serveRedoc (documentUrl) {
+module.exports.serveRedoc = function serveRedoc (documentUrl, opts) {
+  const toKebabCase = (string) =>
+    string
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .replace(/[\s_]+/g, '-')
+      .toLowerCase()
+  const options = {}
+  Object.keys(opts).forEach((key) => {
+    if (!['coerce', 'htmlui', 'basePath'].includes(key)) {
+      options[toKebabCase(key)] = opts[key]
+    }
+  })
+
   return [serve(path.resolve(require.resolve('redoc'), '..')), function renderRedocHtml (req, res) {
     res.type('html').send(renderHtmlPage('ReDoc', `
       <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
     `, `
-      <redoc spec-url="${documentUrl}"></redoc>
+      <redoc spec-url="${documentUrl}" ${Object.keys(options).join(' ')}></redoc>
       <script src="./redoc.standalone.js"></script>
     `))
   }]
 }
 
-module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl) {
+module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl, opts) {
+  const options = {
+    url: documentUrl,
+    dom_id: '#swagger-ui'
+  }
+  Object.keys(opts).forEach((key) => {
+    if (!['coerce', 'htmlui', 'basePath'].includes(key)) {
+      options[key] = opts[key]
+    }
+  })
+
   return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }),
     function returnUiInit (req, res, next) {
       if (req.path.endsWith('/swagger-ui-init.js')) {
         res.type('.js')
         res.send(`window.onload = function () {
-  window.ui = SwaggerUIBundle({
-    url: "${documentUrl}",
-    dom_id: '#swagger-ui'
-  })
+  window.ui = SwaggerUIBundle(${JSON.stringify(options, null, 2)})
 }
         `)
       } else {


### PR DESCRIPTION
The purpose of this PR is to enable the configuration of SwaggerUI and Redoc by allowing users to set their configuration options. This PR uses the pre-exsisting `opts` variable and passes it to Swagger and Redoc, so it can be used. 

Unsure how to test my changes, though guidance would be appreciated.