### PR TITLE
Add Content-Security-Policy header to Swagger HTML response

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -27,7 +27,7 @@ module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl) {
     const hash = require('crypto').createHash(alg).update(scriptContent, 'utf8').digest('base64')
     res
       .type('html')
-      .header('Content-Security-Policy', `script-src '${alg}-${hash}'`)
+      .header('Content-Security-Policy', `script-src 'self' '${alg}-${hash}'`)
       .send(renderHtmlPage('Swagger UI', `
         <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
       `, `

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -15,21 +15,27 @@ module.exports.serveRedoc = function serveRedoc (documentUrl) {
 
 module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl) {
   return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }), function renderSwaggerHtml (req, res) {
-    res.type('html').send(renderHtmlPage('Swagger UI', `
-      <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
-    `, `
-      <div id="swagger-ui"></div>
-      <script src="./swagger-ui-bundle.js"></script>
-      <script src="./swagger-ui-standalone-preset.js"></script>
-      <script>
-        window.onload = function () {
-          window.ui = SwaggerUIBundle({
-            url: "${documentUrl}",
-            dom_id: '#swagger-ui'
-          })
-        }
-      </script>
-    `))
+    const scriptContent = `
+      window.onload = function () {
+        window.ui = SwaggerUIBundle({
+          url: "${documentUrl}",
+          dom_id: '#swagger-ui'
+        })
+      }
+    `
+    const alg = 'sha256'
+    const hash = require('crypto').createHash(alg).update(scriptContent, 'utf8').digest('base64')
+    res
+      .type('html')
+      .header('Content-Security-Policy', `script-src '${alg}-${hash}'`)
+      .send(renderHtmlPage('Swagger UI', `
+        <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
+      `, `
+        <div id="swagger-ui"></div>
+        <script src="./swagger-ui-bundle.js"></script>
+        <script src="./swagger-ui-standalone-preset.js"></script>
+        <script>${scriptContent}</script>
+      `))
   }]
 }
 


### PR DESCRIPTION
Sites implementing Content Security Policy (CSP) will face issues like:

> Refused to execute inline script because it violates the following
Content Security Policy directive: "script-src 'self' cdn.getunleash.io". Either the 'unsafe-inline' keyword, a hash ('sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/E='), or a nonce ('nonce-...') is required to enable inline execution.

Adding a script-src hash helps the browser identify that the script is safe to run.

See https://github.com/wesleytodd/express-openapi/pull/46 for another implementation of the same issue.