### PR TITLE
Update version(s) of NodeJS used for Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ jobs:
       matrix:
         node-version: [14.x, 16.x, 18.x, 20.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install and test


### PR DESCRIPTION
When running the Github Actions as defined in: https://github.com/Megapixel99/express-openapi/blob/main/.github/workflows/test.yml, which should be the same as yours, I noticed that Github was giving the following error while running the tests for every commit (see first and second attached screenshot) even though in the logs it shows the correct version being pulled.
```
The following actions uses node12 which is deprecated and will be forced to run on node16
```
Upon doing some digging I found this StackOverflow post: https://stackoverflow.com/a/76741794 which explained that we needed to change the `actions/checkout` version in order to get rid of the error. After making the change I no longer see the error and it seems the correct versions of NodeJS are being used (see third and fourth attached screenshot).

<img width="1264" alt="Screen Shot 2023-11-01 at 11 07 42" src="https://github.com/wesleytodd/express-openapi/assets/23089578/dfac0ba2-3711-4bf4-ae06-1676e27942c9">

----

<img width="1264" alt="Screen Shot 2023-11-01 at 11 19 52" src="https://github.com/wesleytodd/express-openapi/assets/23089578/a3d3bc96-9541-4856-a01b-a908330ddc3b">

-----
-----

<img width="1264" alt="Screen Shot 2023-11-01 at 11 15 15" src="https://github.com/wesleytodd/express-openapi/assets/23089578/36451505-50fe-4aa7-9b18-67f1bb34d29e">

----

<img width="1264" alt="Screen Shot 2023-11-01 at 11 14 59" src="https://github.com/wesleytodd/express-openapi/assets/23089578/2c507332-273d-43c0-bce8-d9e5852bb80e">
