### PR TITLE
Configure options to allow custom plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Options:
   - `options.coerce`: Enable data type [`coercion`](https://www.npmjs.com/package/ajv#coercing-data-types)
   - `options.htmlui`: Turn on serving `redoc` or `swagger-ui` html ui
   - `options.basePath`: When set, will strip the value of `basePath` from the start of every path.
-The options object can also accept configuration parameters for Swagger and Redoc. The full list of Swagger and Redoc configuration options can be found here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/ and here: https://redocly.com/docs/redoc/config/ respectively.
+  - `options.customScripts`: an array of strings where you can pass in custom scripts which modify the appearance and/or functionality of the Swagger UI.
+  - `options.plugins`: If you have a custom script, you need to pass the name of the script in here (as an array of strings).
+  - The options object can also accept configuration parameters for Swagger and Redoc. The full list of Swagger and Redoc configuration options can be found here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/ and here: https://redocly.com/docs/redoc/config/ respectively.
 
 ##### Coerce
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,6 @@ Options:
   - `options.coerce`: Enable data type [`coercion`](https://www.npmjs.com/package/ajv#coercing-data-types)
   - `options.htmlui`: Turn on serving `redoc` or `swagger-ui` html ui
   - `options.basePath`: When set, will strip the value of `basePath` from the start of every path.
-  - `options.customScripts`: an array of strings where you can pass in custom scripts which modify the appearance and/or functionality of the Swagger UI.
-  - `options.plugins`: If you have a custom script, you need to pass the name of the script in here (as an array of strings).
-  - The options object can also accept configuration parameters for Swagger and Redoc. The full list of Swagger and Redoc configuration options can be found here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/ and here: https://redocly.com/docs/redoc/config/ respectively.
 
 ##### Coerce
 
@@ -285,11 +282,11 @@ Serve an interactive UI for exploring the OpenAPI document.
 [Redoc](https://github.com/Rebilly/ReDoc/) and [SwaggerUI](https://www.npmjs.com/package/swagger-ui) are
 two of the most popular tools for viewing OpenAPI documents and are bundled with the middleware.
 They are not turned on by default but can be with the option mentioned above or by using one
-of these middleware.
+of these middleware. Both interactive UIs also accept an optional object as a function argument which accepts configuration parameters for Swagger and Redoc. The full list of Swagger and Redoc configuration options can be found here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/ and here: https://redocly.com/docs/redoc/config/ respectively.
 
 **Example:**
 
 ```javascript
-app.use('/redoc', oapi.redoc)
-app.use('/swaggerui', oapi.swaggerui)
+app.use('/redoc', oapi.redoc())
+app.use('/swaggerui', oapi.swaggerui())
 ```

--- a/index.js
+++ b/index.js
@@ -127,8 +127,8 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
   middleware.callbacks = middleware.component.bind(null, 'callbacks')
 
   // Expose ui middleware
-  middleware.redoc = ui.serveRedoc(`${routePrefix}.json`, opts)
-  middleware.swaggerui = ui.serveSwaggerUI(`${routePrefix}.json`, opts)
+  middleware.redoc = (options) => ui.serveRedoc(`${routePrefix}.json`, options)
+  middleware.swaggerui = (options) => ui.serveSwaggerUI(`${routePrefix}.json`, options)
 
   // OpenAPI document as json
   router.get(`${routePrefix}.json`, (req, res) => {

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -36,7 +36,7 @@ module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl, opts = {})
   window.ui = SwaggerUIBundle({
     url: '${documentUrl}',
     dom_id: '#swagger-ui',
-    plugins: [${plugins}],
+    ${plugins?.length ? `plugins: [${plugins}],` : ''}
     ...${JSON.stringify(options)}
   })
 }`

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -2,7 +2,7 @@
 const path = require('path')
 const serve = require('serve-static')
 
-module.exports.serveRedoc = function serveRedoc (documentUrl, opts) {
+module.exports.serveRedoc = function serveRedoc (documentUrl, opts = {}) {
   const toKebabCase = (string) =>
     string
       .replace(/([a-z])([A-Z])/g, '$1-$2')
@@ -25,25 +25,22 @@ module.exports.serveRedoc = function serveRedoc (documentUrl, opts) {
   }]
 }
 
-module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl, opts) {
-  const options = {
-    url: documentUrl,
-    dom_id: '#swagger-ui'
-  }
-  Object.keys(opts).forEach((key) => {
-    if (!['coerce', 'htmlui', 'basePath'].includes(key)) {
-      options[key] = opts[key]
-    }
-  })
+module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl, opts = {}) {
+  const { plugins, ...options } = opts
 
   return [serve(path.resolve(require.resolve('swagger-ui-dist'), '..'), { index: false }),
     function returnUiInit (req, res, next) {
       if (req.path.endsWith('/swagger-ui-init.js')) {
         res.type('.js')
         res.send(`window.onload = function () {
-  window.ui = SwaggerUIBundle(${JSON.stringify(options, null, 2)})
-}
-        `)
+  window.ui = SwaggerUIBundle({
+    url: '${documentUrl}',
+    dom_id: '#swagger-ui',
+    plugins: [${plugins}],
+    ...${JSON.stringify(options)}
+  })
+}`
+        )
       } else {
         next()
       }

--- a/test/index.js
+++ b/test/index.js
@@ -106,7 +106,7 @@ suite(name, function () {
 
   test('create a basic valid Swagger UI document and check the HTML title', function (done) {
     const app = express()
-    app.use(openapi().swaggerui)
+    app.use(openapi().swaggerui())
     supertest(app)
       .get(`${openapi.defaultRoutePrefix}.json`)
       .end((err, res) => {
@@ -118,7 +118,7 @@ suite(name, function () {
 
   test('serves onload function in swagger-ui-init.js file', function (done) {
     const app = express()
-    app.use(openapi().swaggerui)
+    app.use(openapi().swaggerui())
     supertest(app)
       .get(`${openapi.defaultRoutePrefix}/swagger-ui-init.js`)
       .end((err, res) => {
@@ -130,7 +130,7 @@ suite(name, function () {
 
   test('create a basic valid ReDoc document and check the HTML title', function (done) {
     const app = express()
-    app.use(openapi().redoc)
+    app.use(openapi().redoc())
     supertest(app)
       .get(`${openapi.defaultRoutePrefix}.json`)
       .end((err, res) => {


### PR DESCRIPTION
Currently, the options are being passed to the Swagger and Redoc UI, but one of the options for the SwaggerUI is `plugins` which requires functions and not strings. This PR allows functions to be passed into the `plugins` option as well as decouples the SwaggerUI options from the custom options that the package exposes.

This PR makes backwards incompatible changes and should be reviewed thoroughly, as well as discussed, before approval.

If the backwards incompatible changes should be moved to a separate PR let me know.