### PR TITLE
chore(codeowner): added @wesleytodd as default code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @wesleytodd


### PR DESCRIPTION
Since we now have a few folks working on the project I wanted to add a bit more formality. I had already set the "require one code owner approval" setting but I forgot that I never had a code owner set. As we all work together on this I was thinking I would slowly add folks for areas they work in. 

Longer term my ideal is to get this publishing with Release Please so I am not in the way of progress. But I just wanted to have a few more checks in place before then to ensure everything runs smoothly.