### PR TITLE
Remove Redoc from the Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const oapi = openapi({
 })
 
 // This will serve the generated json document(s)
-// (as well as swagger-ui or redoc if configured)
+// (as well as the swagger-ui if configured)
 app.use(oapi)
 
 // To add path specific schema you can use the .path middleware
@@ -130,7 +130,7 @@ Options:
 - `document <object>`: Base document on top of which the paths will be added
 - `options <object>`: Options object
   - `options.coerce`: Enable data type [`coercion`](https://www.npmjs.com/package/ajv#coercing-data-types)
-  - `options.htmlui`: Turn on serving `redoc` or `swagger-ui` html ui
+  - `options.htmlui`: Turn on serving `swagger-ui` html ui
   - `options.basePath`: When set, will strip the value of `basePath` from the start of every path.
 
 ##### Coerce
@@ -274,19 +274,16 @@ There are special component middleware for all of the types of component defined
 [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-6).
 Each of which is just the `component` method with a bound type, and behave with the same variadic behavior.
 
-### `OpenApiMiddleware.redoc()`
 ### `OpenApiMiddleware.swaggerui()`
 
 Serve an interactive UI for exploring the OpenAPI document.
 
-[Redoc](https://github.com/Rebilly/ReDoc/) and [SwaggerUI](https://www.npmjs.com/package/swagger-ui) are
-two of the most popular tools for viewing OpenAPI documents and are bundled with the middleware.
-They are not turned on by default but can be with the option mentioned above or by using one
+[SwaggerUI](https://www.npmjs.com/package/swagger-ui) is one of the most popular tools for viewing OpenAPI documents and are bundled with the middleware.
+The UI is not turned on by default but can be with the option mentioned above or by using one
 of these middleware. Both interactive UIs also accept an optional object as a function argument which accepts configuration parameters for Swagger and Redoc. The full list of Swagger and Redoc configuration options can be found here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/ and here: https://redocly.com/docs/redoc/config/ respectively.
 
 **Example:**
 
 ```javascript
-app.use('/redoc', oapi.redoc())
 app.use('/swaggerui', oapi.swaggerui())
 ```

--- a/index.js
+++ b/index.js
@@ -127,7 +127,6 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
   middleware.callbacks = middleware.component.bind(null, 'callbacks')
 
   // Expose ui middleware
-  middleware.redoc = (options) => ui.serveRedoc(`${routePrefix}.json`, options)
   middleware.swaggerui = (options) => ui.serveSwaggerUI(`${routePrefix}.json`, options)
 
   // OpenAPI document as json
@@ -180,11 +179,7 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
   if (opts.htmlui) {
     let ui = opts.htmlui
     if (!Array.isArray(opts.htmlui)) {
-      ui = [opts.htmlui || 'redoc']
-    }
-    if (ui.includes('redoc')) {
-      router.get(`${routePrefix}`, (req, res) => { res.redirect(`${routePrefix}/redoc`) })
-      router.use(`${routePrefix}/redoc`, middleware.redoc)
+      ui = [opts.htmlui]
     }
     if (ui.includes('swagger-ui')) {
       router.get(`${routePrefix}`, (req, res) => { res.redirect(`${routePrefix}/swagger-ui`) })

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -2,29 +2,6 @@
 const path = require('path')
 const serve = require('serve-static')
 
-module.exports.serveRedoc = function serveRedoc (documentUrl, opts = {}) {
-  const toKebabCase = (string) =>
-    string
-      .replace(/([a-z])([A-Z])/g, '$1-$2')
-      .replace(/[\s_]+/g, '-')
-      .toLowerCase()
-  const options = {}
-  Object.keys(opts).forEach((key) => {
-    if (!['coerce', 'htmlui', 'basePath'].includes(key)) {
-      options[toKebabCase(key)] = opts[key]
-    }
-  })
-
-  return [serve(path.resolve(require.resolve('redoc'), '..')), function renderRedocHtml (req, res) {
-    res.type('html').send(renderHtmlPage('ReDoc', `
-      <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-    `, `
-      <redoc spec-url="${documentUrl}" ${Object.keys(options).join(' ')}></redoc>
-      <script src="./redoc.standalone.js"></script>
-    `))
-  }]
-}
-
 module.exports.serveSwaggerUI = function serveSwaggerUI (documentUrl, opts = {}) {
   const { plugins, ...options } = opts
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "http-errors": "^2.0.0",
     "merge-deep": "^3.0.2",
     "path-to-regexp": "^6.2.1",
-    "redoc": "^2.0.0-alpha.41",
     "router": "^1.3.3",
     "serve-static": "^1.13.2",
     "swagger-parser": "^10.0.3",

--- a/test/index.js
+++ b/test/index.js
@@ -128,18 +128,6 @@ suite(name, function () {
       })
   })
 
-  test('create a basic valid ReDoc document and check the HTML title', function (done) {
-    const app = express()
-    app.use(openapi().redoc())
-    supertest(app)
-      .get(`${openapi.defaultRoutePrefix}.json`)
-      .end((err, res) => {
-        assert(!err, err)
-        assert(res.text.includes('<title>ReDoc</title>'))
-        done()
-      })
-  })
-
   test('load routes from the express app', function (done) {
     const app = express()
     const oapi = openapi()


### PR DESCRIPTION
Remove Redoc ui, routes, and tests from the Repo.

The desire to remove Redoc was indicated here: https://github.com/wesleytodd/express-openapi/pull/50#discussion_r1379485560 (as well as other places, potentially)

This PR makes backwards incompatible changes and should be reviewed thoroughly, as well as discussed, before approval.
