### PR TITLE
feat!: add support for routes passed in as arrays

### DIFF
--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -79,6 +79,18 @@ function iterateStack (path, routeLayer, layer, cb) {
   if (!layer.route) {
     return
   }
+  if (Array.isArray(layer.route.path)) {
+    const r = layer.regexp.toString()
+    layer.route.path.forEach((p, i) => iterateStack(path + p, layer, {
+      ...layer,
+      // Chacking if p is a string here since p may be a regex expression
+      keys: layer.keys.filter((k) => typeof p === 'string' ? p.includes(`/:${k.name}`) : false),
+      // There may be an issue here if the regex has a '|', but that seems to only be the case with user defined regex
+      regexp: new RegExp(`(${r.substring(2, r.length - 3).split('|')[i]})`),
+      route: { ...layer.route, path: '' }
+    }, cb))
+    return
+  }
   layer.route.stack.forEach((l) => iterateStack(path + layer.route.path, layer, l, cb))
 }
 

--- a/test/_routes.js
+++ b/test/_routes.js
@@ -94,5 +94,36 @@ module.exports = function () {
           done()
         })
     })
+
+    test('serve routes in an array as different routes', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get(['/route/:a', '/route/b', '/routeC'], oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{a}')
+          assert.strictEqual(Object.keys((res.body.paths))[1], '/route/b')
+          assert.strictEqual(Object.keys((res.body.paths))[2], '/routeC')
+          done()
+        })
+    })
   })
 }


### PR DESCRIPTION
Express natively supports passing multiple paths into the same function as an array as seen in the file [test/_routes.js](https://github.com/wesleytodd/express-openapi/compare/release/v1.0.0...support-array-paths#diff-ee1b2dd418c624557d9eea34623a9a1c55c5214bea678f284a8afd0a3dda7234R103). This PR adds support for passing multiple paths.

This PR was made under the assumption the array of paths would not include regex expressions, and the code may break if the array of paths has a regex expression in it (as of the creation of  this PR). I do not believe this will be a common use case; however, it is still possible.
