### PR TITLE
fix: support express@5 router

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -69,7 +69,6 @@ module.exports = function generateDocument (baseDocument, router, basePath) {
 
 function iterateStack (path, routeLayer, layer, cb) {
   cb(path, routeLayer, layer)
-
   if (layer.name === 'router') {
     layer.handle.stack.forEach(l => {
       path = path || ''
@@ -113,6 +112,16 @@ function processComplexMatch (thing, keys) {
 
 // https://github.com/expressjs/express/issues/3308#issuecomment-300957572
 function split (thing, keys) {
+  // In express v5 the router layers regexp (path-to-regexp@3.2.0)
+  // has some additional handling for end of lines, remove those
+  //
+  // layer.regexp
+  // v4 ^\\/sub-route\\/?(?=\\/|$)
+  // v5 ^\\/sub-route(?:\\/(?=$))?(?=\\/|$)
+  //
+  // l.regexp
+  // v4 ^\\/endpoint\\/?$
+  // v5 ^\\/endpoint(?:\\/)?$
   if (typeof thing === 'string') {
     return thing.split('/')
   } else if (thing.fast_slash) {
@@ -122,6 +131,8 @@ function split (thing, keys) {
       .toString()
       .replace('\\/?', '')
       .replace('(?=\\/|$)', '$')
+      // Added this line to catch the express v5 case after the v4 part is stripped off
+      .replace('(?:\\/(?=$))?$', '$')
       .match(/^\/\^((?:\\[.*+?^${}()|[\]\\/]|[^.*+?^${}()|[\]\\/])*)\$\//)
     return match
       ? match[1].replace(/\\(.)/g, '$1').split('/')

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
   },
   "scripts": {
     "test": "standard && mocha",
-    "prepublishOnly": "npm t",
+    "prepublishOnly": "EXPRESS_MAJOR=4 mocha && EXPRESS_MAJOR=5 mocha",
     "postpublish": "git push origin && git push origin --tags"
   },
   "devDependencies": {
     "express": "^4.18.2",
+    "express4": "github:expressjs/express#4.18.3-staging",
+    "express5": "npm:express@^5.0.0-beta.1",
     "mocha": "^10.2.0",
     "standard": "^17.1.0",
     "supertest": "^6.3.3"

--- a/test/index.js
+++ b/test/index.js
@@ -3,11 +3,20 @@ const { suite, test } = require('mocha')
 const assert = require('assert')
 const util = require('util')
 const supertest = require('supertest')
-const express = require('express')
 const SwaggerParser = require('swagger-parser')
 const openapi = require('../')
 const { name } = require('../package.json')
 const YAML = require('yaml')
+
+// We support testing with different major versions of express
+let spec = 'express'
+if (process.env.EXPRESS_MAJOR) {
+  if (!['4', '5'].includes(process.env.EXPRESS_MAJOR)) {
+    throw new Error('EXPRESS_MAJOR contained an invalid value')
+  }
+  spec += process.env.EXPRESS_MAJOR
+}
+const express = require(spec)
 
 function logDocument (doc) {
   console.log(util.inspect(doc, { depth: null }))


### PR DESCRIPTION
Fixes #57, although I did not see the same error as reported. This does get the tests passing in with express@5 though.