### PR TITLE
Add support for ajv-keywords

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,11 +63,11 @@ module.exports = function ExpressOpenApi (_routePrefix, _doc, _opts) {
   }
 
   // Validate path middleware
-  middleware.validPath = function (schema = {}) {
+  middleware.validPath = function (schema = {}, pathOpts = {}) {
     let validate
     function validSchemaMiddleware (req, res, next) {
       if (!validate) {
-        validate = makeValidator(middleware, getSchema(validSchemaMiddleware), opts)
+        validate = makeValidator(middleware, getSchema(validSchemaMiddleware), { ...pathOpts, ...opts })
       }
       return validate(req, res, next)
     }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,6 +1,7 @@
 'use strict'
 const Ajv = require('ajv')
 const addFormats = require('ajv-formats')
+const addKeywords = require('ajv-keywords')
 const httpErrors = require('http-errors')
 const merge = require('merge-deep')
 
@@ -93,6 +94,8 @@ module.exports = function makeValidatorMiddleware (middleware, schema, opts) {
         strict: opts.strict === true ? opts.strict : false
       })
       addFormats(ajv)
+
+      if (opts.keywords) { addKeywords(ajv, opts.keywords) }
     }
 
     if (!validate) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
+    "ajv-keywords": "^5.1.0",
     "http-errors": "^2.0.0",
     "merge-deep": "^3.0.3",
     "path-to-regexp": "^6.2.1",


### PR DESCRIPTION
Useful to add custom validations.

I am using it in [sequelize-to-openapi](https://github.com/techntools/sequelize-to-openapi)