### PR TITLE
Add support for regex wildcard group

### DIFF
--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -29,7 +29,12 @@ module.exports = function generateDocument (baseDocument, router, basePath) {
       if (routeLayer && routeLayer.keys && routeLayer.keys.length) {
         const keys = {}
 
-        const params = routeLayer.keys.map((k) => {
+        const params = routeLayer.keys.map((k, i) => {
+          const prev = i > 0 && routeLayer.keys[i - 1]
+          // do not count parameters without a name if they are next to a named parameter
+          if (typeof k.name === 'number' && prev && prev.offset + prev.name.length + 1 >= k.offset) {
+            return null
+          }
           let param
           if (schema.parameters) {
             param = schema.parameters.find((p) => p.name === k.name && p.in === 'path')
@@ -45,6 +50,7 @@ module.exports = function generateDocument (baseDocument, router, basePath) {
             schema: k.schema || { type: 'string' }
           }, param || {})
         })
+          .filter((e) => e)
 
         if (schema.parameters) {
           schema.parameters.forEach((p) => {
@@ -55,7 +61,7 @@ module.exports = function generateDocument (baseDocument, router, basePath) {
         }
 
         operation.parameters = params
-        path = pathToRegexp.compile(path)(keys, { encode: (value) => value })
+        path = pathToRegexp.compile(path.replace(/\*|\(\*\)/g, '(.*)'))(keys, { encode: (value) => value })
       }
 
       doc.paths[path] = doc.paths[path] || {}

--- a/test/_regexRoutes.js
+++ b/test/_regexRoutes.js
@@ -1,0 +1,397 @@
+'use strict'
+const { suite, test } = require('mocha')
+const assert = require('assert')
+const supertest = require('supertest')
+const express = require('express')
+const openapi = require('..')
+
+module.exports = function () {
+  suite('regex routes', function () {
+    test('serve routes with a * wildcard', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:param*', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{param}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 2)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].in, 'path')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'param')
+          done()
+        })
+    })
+
+    test('serve routes with a * wildcard in parentheses', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:param(*)', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{param}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 1)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].in, 'path')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'param')
+          done()
+        })
+    })
+
+    test('serve routes in an array as different routes when one route has a * wildcard', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get(['/route/:param*', '/route/b', '/routeC'], oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{param}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 1)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].in, 'path')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'param')
+          assert.strictEqual(Object.keys((res.body.paths))[1], '/route/b')
+          assert.strictEqual(Object.keys((res.body.paths))[2], '/routeC')
+          done()
+        })
+    })
+
+    test('serve route with param and a * wildcard', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:param/desc/*', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{param}/desc/{0}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 2)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'param')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 0)
+          done()
+        })
+    })
+
+    test('serve routes with only a * wildcard', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/*', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/{0}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 1)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 0)
+          done()
+        })
+    })
+
+    test('serve routes with a * wildcard parameter and a named parameter', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/*/:param', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{0}/{param}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 2)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 0)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 'param')
+          done()
+        })
+    })
+
+    test('serve routes with two parameters and a hardcoded desc then a wildcard parameter', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:paramA/:paramB/desc/*', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{paramA}/{paramB}/desc/{0}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 3)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'paramA')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 'paramB')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[2].name, 0)
+          done()
+        })
+    })
+
+    test('serve routes with two parameters and a wildcard parameter', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:paramA/:paramB/*', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{paramA}/{paramB}/{0}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 3)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'paramA')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 'paramB')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[2].name, 0)
+          done()
+        })
+    })
+
+    test('serve routes with a parameter and another named, grouped, wildcard parameter', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:paramA/:paramB(*)', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{paramA}/{paramB}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 2)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'paramA')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 'paramB')
+          done()
+        })
+    })
+
+    test('serve multiple routes with a parameter and another named, grouped, wildcard parameter', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get(['/route/:paramA/:paramB(*)', '/cars/:paramA/:paramB(*)'], oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{paramA}/{paramB}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 4)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'paramA')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 'paramB')
+          done()
+        })
+    })
+
+    test('serve routes with a parameter and another named wildcard parameter', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:paramA/:paramB*', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{paramA}/{paramB}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 3)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'paramA')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 'paramB')
+          done()
+        })
+    })
+
+    test('serve routes with a parameter and a * wildcard', function (done) {
+      const app = express()
+
+      const oapi = openapi()
+      app.use(oapi)
+      app.get('/route/:param/*', oapi.path({
+        summary: 'Test route.',
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }))
+
+      supertest(app)
+        .get(`${openapi.defaultRoutePrefix}.json`)
+        .expect(200, (err, res) => {
+          assert(!err, err)
+          assert.strictEqual(Object.keys((res.body.paths))[0], '/route/{param}/{0}')
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters.length, 2)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[1].name, 0)
+          assert.strictEqual(res.body.paths[Object.keys((res.body.paths))[0]].get.parameters[0].name, 'param')
+          done()
+        })
+    })
+  })
+}

--- a/test/index.js
+++ b/test/index.js
@@ -655,5 +655,6 @@ suite(name, function () {
 
   // Other tests
   require('./_validate')()
+  require('./_regexRoutes')()
   require('./_routes')()
 })


### PR DESCRIPTION
Looking at Route Paths in https://expressjs.com/en/guide/routing.html, Express supports routes such as `/ab?cd` and `/ab*cd`; however, when trying to implement `/ab/cd(*)` (which is mentioned in [this issue](https://github.com/expressjs/express/issues/2495)), you would receive the following error: `Invalid regular expression: /^(?:*)$/i: Nothing to repeat`. This PR should fix that error.