### PR TITLE
fix: remove `merge-deep` from the validation

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -3,7 +3,6 @@ const Ajv = require('ajv')
 const addFormats = require('ajv-formats')
 const addKeywords = require('ajv-keywords')
 const httpErrors = require('http-errors')
-const merge = require('merge-deep')
 
 const BASE_REQ_SCHEMA = {
   type: 'object',
@@ -37,7 +36,7 @@ module.exports = function makeValidatorMiddleware (middleware, schema, opts) {
   let validate
 
   function makeValidator () {
-    const reqSchema = merge({}, BASE_REQ_SCHEMA)
+    const reqSchema = structuredClone(BASE_REQ_SCHEMA)
 
     // Compile req schema on first request
     // Build param validation

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ajv-formats": "^2.1.1",
     "ajv-keywords": "^5.1.0",
     "http-errors": "^2.0.0",
-    "merge-deep": "^3.0.3",
     "path-to-regexp": "^6.2.1",
     "router": "^1.3.8",
     "serve-static": "^1.15.0",


### PR DESCRIPTION
We used to use `merge-deep` to assign parameters to a new object; however, we can use `structuredClone`  to do the same thing and remove the dependency on `merge-deep`. `structuredClone` only works on node 17+ but node 16 reached EOL in September 2023 per https://endoflife.date/nodejs and https://nodejs.org/en/blog/announcements/nodejs16-eol.