### PR TITLE
fix: Remove `router` dependency as it comes from Express that is marked as peerDependency now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,15 @@
     "prepublishOnly": "EXPRESS_MAJOR=4 mocha && EXPRESS_MAJOR=5 mocha",
     "postpublish": "git push origin && git push origin --tags"
   },
+  "peerDependencies": {
+    "express": ">= 4.17.3 < 6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "express": {
+      "optional": true,
+      "meta": "This package imports `router`, which comes with `express`."
+    }
+  },
   "devDependencies": {
     "express": "^4.18.2",
     "express4": "github:expressjs/express#4.19.2",
@@ -34,7 +43,6 @@
     "ajv-keywords": "^5.1.0",
     "http-errors": "^2.0.0",
     "path-to-regexp": "^6.2.1",
-    "router": "^1.3.8",
     "serve-static": "^1.15.0",
     "swagger-parser": "^10.0.3",
     "swagger-ui-dist": "^5.11.8",


### PR DESCRIPTION
Remove `router` dependency and mark `express` as peer dependency. This way we get rid of the security warnings when we npm install this package. We also allow the use of the Router that comes with whatever express version the host application has.