### PR TITLE
Fix issue #78: Separate OpenAPI specs for multiple middleware instances

### DIFF
--- a/lib/generate-doc.js
+++ b/lib/generate-doc.js
@@ -3,7 +3,7 @@ const pathToRegexp = require('path-to-regexp')
 const minimumViableDocument = require('./minimum-doc')
 const { get: getSchema, set: setSchema } = require('./layer-schema')
 
-module.exports = function generateDocument (baseDocument, router, basePath) {
+module.exports = function generateDocument (baseDocument, router, basePath, ownerMiddleware) {
   // Merge document with select minimum defaults
   const doc = Object.assign({
     openapi: minimumViableDocument.openapi
@@ -20,6 +20,11 @@ module.exports = function generateDocument (baseDocument, router, basePath) {
       }
       const schema = getSchema(layer.handle)
       if (!schema || !layer.method) {
+        return
+      }
+
+      // If ownerMiddleware is provided, only exclude routes owned by other OpenAPI middlewares
+      if (ownerMiddleware && layer.handle._ownerMiddleware && layer.handle._ownerMiddleware !== ownerMiddleware) {
         return
       }
 


### PR DESCRIPTION
If this is by design, feel free to close this PR. This PR fixes #78 and separates out the OpenAPI specs if they are registered to different middleware.

- Store owned routes directly on middleware instance using Set
- Filter routes based on ownership when generating specs
- Ensures each middleware only includes its own routes